### PR TITLE
Add emittter to the server exports

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -23,9 +23,12 @@ var processWrapper = new EmitterWrapper(process);
 
 var log = logger.create();
 
+var emitter;
 
 var start = function(injector, config, launcher, globalEmitter, preprocess, fileList, webServer,
     capturedBrowsers, socketServer, executor, done) {
+  
+  emitter = globalEmitter;
 
   config.frameworks.forEach(function(framework) {
     injector.get('framework:' + framework);
@@ -277,6 +280,7 @@ var createSocketIoServer = function(webServer, executor, config) {
   return server;
 };
 
+exports.emitter = function(){ return emitter; };
 
 exports.start = function(cliOptions, done) {
   // apply the default logger config (and config from CLI) as soon as we can


### PR DESCRIPTION
Adding the emitter to the exports allows a developer to stop a running set of (singleRun) tests using the below code:
    karma.emitter().emit('run_complete', [], {exitCode: 0});

This could be more elegant since doing this will stop a running set of tests but leaves the browser hanging. Eventually the browser timeout cleans it up with a bad error message. It would be nicer to stop the tests without the browser crashing.
